### PR TITLE
docs: improve various doc syntaxes

### DIFF
--- a/docs/source/deps/etcd-production.rst
+++ b/docs/source/deps/etcd-production.rst
@@ -49,7 +49,7 @@ For each etcd server, generate a certificate as follows::
     echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
 
 .. note::
-   If your servers will be reached from other IPs or DNS aliases, make sure to reference them in the ADDRESS variable
+   If your servers will be reached from other IPs or DNS aliases, make sure to reference them in the **ADDRESS** variable
 
 
 You now have to deploy the generated keys and certificates in the :file:`/etc/etcd/` directory of each server node. For example for node1::
@@ -77,11 +77,12 @@ etcd needs to be configured on each server node in the /etc/etcd/etcd.conf confi
     ETCD_PEER_CLIENT_CERT_AUTH=true
     ETCD_TRUSTED_CA_FILE=/etc/etcd/etcd-ca.crt
     ETCD_CERT_FILE="/etc/etcd/server.crt"
-    ETCD_KEY_FILE="/etc/etcd/server.key"                                                                                                                                                                                                   ETCD_PEER_KEY_FILE=/etc/etcd/server.key
+    ETCD_KEY_FILE="/etc/etcd/server.key"
+    ETCD_PEER_KEY_FILE=/etc/etcd/server.key
     ETCD_PEER_CERT_FILE=/etc/etcd/server.crt
 
 .. note::
-    ETCD_NAME, ETCD_ADVERTISE_CLIENT_URLS, ETCD_INITIAL_ADVERTISE_PEER_URLS have to be adapted for each server node.
+    **ETCD_NAME**, **ETCD_ADVERTISE_CLIENT_URLS**, **ETCD_INITIAL_ADVERTISE_PEER_URLS** have to be adapted for each server node.
 
 Finally, you may enable and start the service on all etcd nodes::
 
@@ -104,7 +105,7 @@ To check if your etcd server is running correctly you may do::
 Configure etcd for pcocc
 ************************
 
-Before enabling authentication, configure a "root" user in etcd:
+Before enabling authentication, configure a ``root`` user in etcd::
 
     etcdctl --endpoints="https://node1.mydomain.com:2379" --cacert=~/etcd-ca/ca.pem  user add root
 

--- a/docs/source/deps/openvswitch.rst
+++ b/docs/source/deps/openvswitch.rst
@@ -2,7 +2,7 @@
 Installing Open vSwitch
 #######################
 
-pcocc relies on Open vSwitch to provide the VMs with private virtual networks. Open vSwitch can be downloaded from `here <http://openvswitch.org/download/>`_. The official `installation guide <http://docs.openvswitch.org/en/latest/intro/install/general/>`_ can be used as an additional source for this process.
+pcocc relies on Open vSwitch to provide the VMs with private virtual networks. Open vSwitch can be downloaded from `official website <http://openvswitch.org/download/>`_. The official `installation guide <http://docs.openvswitch.org/en/latest/intro/install/general/>`_ can be used as an additional source for this process.
 
 ****************
 Building the RPM
@@ -27,7 +27,7 @@ Installation and configuration
 
 Install the RPM on all compute nodes or wait for it to be pulled as a dependency by pcocc. You'll also want to enable the service and start it (or reboot your compute nodes)::
 
-    #On all compute nodes as root
+    # On all compute nodes as root
     systemctl enable openvswitch
     systemctl start openvswitch
 

--- a/docs/source/deps/python-etcd.rst
+++ b/docs/source/deps/python-etcd.rst
@@ -15,4 +15,4 @@ The RPM building process is quite straightforward::
     cd python-etcd-0.4.4
     python setup.py bdist_rpm
 
-Put the resulting packages in your local repositories and install python-etcd on your front-end and compute nodes or wait for pcocc to pull it as a dependency.
+Put the resulting packages in your local repositories and install ``python-etcd`` on your front-end and compute nodes or wait for pcocc to pull it as a dependency.

--- a/docs/source/deps/slurm-spank.rst
+++ b/docs/source/deps/slurm-spank.rst
@@ -36,7 +36,7 @@ Put the resulting packages in your repositories and install slurm-spank-plugins-
 Configuring SPANK
 *****************
 
-For the pcocc plugin to be properly loaded, we have to instruct the Slurm SPANK infrastructure to load all LUA addons in the standard /etc/slurm/lua.d directory by setting the following content inside :file:`/etc/slurm/plugstack.conf`:
+For the pcocc plugin to be properly loaded, we have to instruct the Slurm SPANK infrastructure to load all LUA addons in the standard :file:`/etc/slurm/lua.d` directory by setting the following content inside :file:`/etc/slurm/plugstack.conf`:
 
 .. code-block:: text
     :caption: /etc/slurm/plugstack.conf

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -41,11 +41,21 @@ This guide also assumes that you already have a working Slurm cluster. The follo
 RPM based installation
 **********************
 
-The easiest way to install pcocc on a RPM based distribution is to build a package and install it on all your compute and front-end nodes. Starting from the source distribution, you can go to the root directory of the sources and run the following command to build a RPM:
+Pre-generated RPM
+------------------
+
+Pre-generated RPM could be downloaded directly from pcocc website https://github.com/cea-hpc/pcocc/releases/latest.
+
+Rebuild from sources
+--------------------
+
+From the source distribution, you can go to the root directory of the sources and run the following command to build a RPM::
 
     python setup.py bdist_rpm
 
-You may need to install the *rpm-build* package first. The resulting pcocc RPM should be installed with the package manager which will pull all the necessary dependencies from your configured repositories. If you are missing something, please have a look at the guidelines provided in the previous section.
+You may need to install the ``rpm-build`` package first.
+
+Pcocc RPM should be installed on all your compute and front-end nodes using to the package manager which will pull all the necessary dependencies from your configured repositories. If you are missing something, please have a look at the guidelines provided in the previous section.
 
 
 Prepare compute nodes and required services
@@ -56,7 +66,7 @@ Hardware virtualization support
 
 Check that your compute nodes processors have virtualization extensions enabled, and if not (and possible) enable them in the BIOS::
 
-    #This command should return a match
+    # This command should return a match
     grep -E '(vmx|svm)' /proc/cpuinfo
 
 
@@ -67,7 +77,7 @@ The kvm module must be loaded on all compute nodes and accessible (rw permission
 
    KERNEL=="kvm", GROUP=="xxx", MODE="xxx"
 
-Adjust the GROUP and MODE permissions to fit your needs. If virtualization exetensions are not enabled or access to kvm is not provided, pcocc will run Qemu in emulation mode which will be slow.
+Adjust the **GROUP** and **MODE** permissions to fit your needs. If virtualization extensions are not enabled or access to kvm is not provided, pcocc will run Qemu in emulation mode which will be slow.
 
 
 Slurm setup
@@ -96,7 +106,7 @@ Make sure that your node definitions have coherent memory size et CPU count para
     NodeName=Node1 CPUs=8 RealMemory=16000 State=UNKNOWN
     ...
 
-Note how DefMemPerCPU times CPUs equals RealMemory. As described in the requirements section, you need to enable Lua SPANK plugins. Follow this guide if you haven't done it yet:
+Note how **DefMemPerCPU** times **CPUs** equals **RealMemory**. As described in the requirements section, you need to enable Lua SPANK plugins. Follow this guide if you haven't done it yet:
 
 .. toctree::
    :maxdepth: 1
@@ -124,7 +134,7 @@ Edit pcocc configuration files
 
 The configuration of pcocc itself consists in editing YAML files in :file:`/etc/pcocc/`. These files must be present on all front-end and compute nodes.
 
-First, create a root-owned file named :file:`/etc/pcocc/etcd-password` with 0600 permissions containing the etcd root password in plain text.
+First, create a root-owned file named :file:`/etc/pcocc/etcd-password` with ``0600`` permissions containing the etcd root password in plain text.
 
 The :file:`/etc/pcocc/batch.yaml` configuration file contains configuration pertaining to Slurm and etcd. Define the hostnames and client port of your etcd servers:
 
@@ -141,11 +151,11 @@ The :file:`/etc/pcocc/batch.yaml` configuration file contains configuration pert
      etcd-protocol: http
      etcd-auth-type: password
 
-If you enabled TLS, select the *https* etcd-protocol and define the **etcd-ca-cert** parameter to the path of the CA certificate created for etcd (see :ref:`Deploy a secure etcd cluster <etcd-production>`).
+If you enabled TLS, select the *https* **etcd-protocol** and define the **etcd-ca-cert** parameter to the path of the CA certificate created for etcd (see :ref:`Deploy a secure etcd cluster <etcd-production>`).
 
 The sample network configuration in :file:`/etc/pcocc/networks.yaml` defines a single Ethernet network named *nat-rssh*. It allows VMs of each virtual cluster to communicate over a private Ethernet network and provides them with a network gateway to reach external hosts. Routing is performed by NAT (Network Address Translation) using the hypervisor IP as source. It also performs reverse NAT from ports allocated dynamically on the hypervisor to the SSH port of each VM. DHCP and DNS servers are spawned for each virtual cluster to provide network IP addresses for the VMs. For a more detailed description of network parameters, please see :ref:`pcocc-resources.yaml(5)<networks.yaml>`.
 
-Most parameters can be kept as-is for the purpose of this tutorial, as long as the default network ranges do not conflict with your existing IP addressing plan. The **host-if-suffix** parameter can be used if compute nodes have specific hostnames to address each network interface. For example, if a compute node known by Slurm as computeXX can reached more efficiently via IPoIB at the computeXX-ib address, the **host-if-suffix** parameter can be set to *-ib* so that the Ethernet tunnels between hypervisors transit over IPoIB. Raising the MTU may also help improve performance if your physical network allows it.
+Most parameters can be kept as-is for the purpose of this tutorial, as long as the default network ranges do not conflict with your existing IP addressing plan. The **host-if-suffix** parameter can be used if compute nodes have specific hostnames to address each network interface. For example, if a compute node, known by Slurm as ``computeXX``, can be reached more efficiently via IPoIB at the ``computeXX-ib`` address, the **host-if-suffix** parameter can be set to *-ib* so that the Ethernet tunnels between hypervisors transit over IPoIB. Raising the MTU may also help improve performance if your physical network allows it.
 
 The :file:`/etc/pcocc/resources.yaml` configuration file defines sets of resources, currently only networks, that templates may reference. The default configuration is also sufficient for this tutorial: a single resource set is defined, *default* which only provides the *nat-rssh* network. See :ref:`pcocc-resources.yaml(5)<resources.yaml>` for more information about this file.
 


### PR DESCRIPTION
Fix few typos in rst files. Mostly:
 - missing '::' at paragraph ends
 - double backticks for keywords