### PR TITLE
Add MinMemoryCPU case for memory in GiB

### DIFF
--- a/lib/pcocc/Batch.py
+++ b/lib/pcocc/Batch.py
@@ -1807,6 +1807,10 @@ class SlurmManager(EtcdManager):
         if match:
             return int(match.group(1))
 
+        match = re.search(r'MinMemoryCPU=(\d+)G', raw_output)
+        if match:
+            return int(match.group(1)) * 1024
+
         # Else, try a per node basis:
         match = re.search(r'MinMemoryNode=(\d+)M', raw_output)
         if match:


### PR DESCRIPTION
When trying to launch a job I get the following error message:

```
(pcocc/6795629) [odf1@tcn179 ~]$ Failed to read memory per core
```

Looking at the code I realized the error: there is no detection mechanism for `MinMemoryCPU` in GiB, but Slurm does report in GiB in this case:

```
[odf1@tcn179 ~]$ scontrol show job 6780602 | grep -i mem
   RunTime=2-05:38:01 TimeLimit=3-23:35:00 TimeMin=N/A
   TRES=cpu=1,mem=8G,node=1
   MinCPUsNode=1 MinMemoryCPU=8G MinTmpDiskNode=0
```