### PR TITLE
PKey is a hexadecimal number

### DIFF
--- a/lib/pcocc/IBNetwork.py
+++ b/lib/pcocc/IBNetwork.py
@@ -227,7 +227,7 @@ required:
                     continue
 
                 # Find keys matching a valid PKey value
-                m = re.match(r'{0}/(0x\d\d\d\d)$'.format(pkey_path), child.key)
+                m = re.match(r'{0}/(0x[0-9a-f][0-9a-f][0-9a-f][0-9a-f])$'.format(pkey_path), child.key)
                 if not m:
                     logging.warning("Invalid entry in PKey directory: " +
                                     child.key)


### PR DESCRIPTION
We were hitting this bug where any hexadecimal number with an alphabetic character in it couldn't access the Infiniband partition. Maybe the behavior is intended, but I couldn't think of a reason why.