### PR TITLE
Fix regex to detect memory per node and CPU when the unit is GiB

### DIFF
--- a/lib/pcocc/Batch.py
+++ b/lib/pcocc/Batch.py
@@ -1807,18 +1807,18 @@ class SlurmManager(EtcdManager):
         if match:
             return int(match.group(1))
 
-        match = re.search(r'MinMemoryCPU=(\d+)G', raw_output)
+        match = re.search(r'MinMemoryCPU=([\d\.]+)G', raw_output)
         if match:
-            return int(match.group(1)) * 1024
+            return int(float(match.group(1)) * 1024)
 
         # Else, try a per node basis:
         match = re.search(r'MinMemoryNode=(\d+)M', raw_output)
         if match:
             return int(match.group(1)) // self.num_cores
 
-        match = re.search(r'MinMemoryNode=(\d+)G', raw_output)
+        match = re.search(r'MinMemoryNode=([\d\.]+)G', raw_output)
         if match:
-            return int(match.group(1)) * 1024 // self.num_cores
+            return int(float(match.group(1)) * 1024) // self.num_cores
 
         raise BatchError("Failed to read memory per core")
 


### PR DESCRIPTION
I've encountered a situation where `MinMemoryCPU=7.50G`, which results in `Failed to read memory per core`. This patch fixes that issue.